### PR TITLE
Update docker-compose.yml - Replace MySQL with MariaDB (11.6.2)

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -14,7 +14,7 @@ services:
 
   database:
     container_name: database
-    image: mysql:5.7
+    image: mariadb:11.6.2
     restart: always
     ports:
       - "3306:3306"


### PR DESCRIPTION
## 📑 Description
Update docker-compose.yml - Replace MySQL with MariaDB (11.6.2)

## ✅ Checks
- [X] My pull request adheres to the code style of this project
- [X] My code requires changes to the documentation
- [X] I have updated the documentation as required
- [X] All the tests have passed

## ☢️ Does this introduce a breaking change?
- [ ] Yes
- [X] No

---

## Summary by Sourcery

Deployment:
- Replace MySQL with MariaDB (11.6.2) in the docker-compose.yml file.

<!-- Korbit AI PR Description Start -->
## Description by Korbit AI

### What change is being made?

Replace the MySQL 5.7 image with the MariaDB 11.6.2 image in the `docker-compose.yml` file for the database service.

### Why are these changes being made?

MariaDB is a community-developed fork of MySQL and offers similar features while often providing better performance and additional functionalities. This change is made to take advantage of MariaDB's enhancements while maintaining compatibility with existing MySQL setups.

> Is this description stale? Ask me to generate a new description by commenting `/korbit-generate-pr-description`
<!-- Korbit AI PR Description End -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Updated database service from MySQL 5.7 to MariaDB 11.6.2
	- No changes to database configuration or environment settings

<!-- end of auto-generated comment: release notes by coderabbit.ai -->